### PR TITLE
fix: linux mouse boundaries and virtual screen size

### DIFF
--- a/Assets/Scripts/Core/Game.cs
+++ b/Assets/Scripts/Core/Game.cs
@@ -387,7 +387,7 @@ namespace Core {
         }
 
         public void LockCursor() {
-            Cursor.lockState = CursorLockMode.Confined;
+            Cursor.lockState = CursorLockMode.Locked;
         }
 
         public void FadeToBlack() {

--- a/Assets/Scripts/Core/Player/User.cs
+++ b/Assets/Scripts/Core/Player/User.cs
@@ -438,8 +438,8 @@ namespace Core.Player {
             // clamp to virtual screen 
             var extentsX = Screen.width * Mathf.Pow(sensitivityX, -1);
             var extentsY = Screen.height * Mathf.Pow(sensitivityY, -1);
-            _mousePositionScreen.x = Math.Max(-extentsX, Math.Min(extentsX, _mousePositionScreen.x));
-            _mousePositionScreen.y = Math.Max(-extentsY, Math.Min(extentsY, _mousePositionScreen.y));
+            _mousePositionScreen.x = Math.Max(Screen.width - extentsX, Math.Min(extentsX, _mousePositionScreen.x));
+            _mousePositionScreen.y = Math.Max(Screen.height - extentsY, Math.Min(extentsY, _mousePositionScreen.y));
 
             // we're done
             pitchMouseInput = pitch;


### PR DESCRIPTION
Two small fixes for mouse input that were mentioned on Discord some time ago:
1. CursorLockMode.Locked is required for Linux build with relative mouse, this change should be transparent for Windows users
2.  Fixed mouse cursor's virtual screen boundaries to have the same size in all directions from screen center