### PR TITLE
fix: #72 - same mouse scroll speed on Linux and Win

### DIFF
--- a/Assets/InputActions/FlyDangerousActions.cs
+++ b/Assets/InputActions/FlyDangerousActions.cs
@@ -1608,7 +1608,7 @@ public partial class @FlyDangerousActions : IInputActionCollection2, IDisposable
                     ""type"": ""PassThrough"",
                     ""id"": ""4228771a-3eee-4250-bb1b-1186f85c0c5d"",
                     ""expectedControlType"": ""Vector2"",
-                    ""processors"": """",
+                    ""processors"": ""NormalizeMouseScroll"",
                     ""interactions"": """"
                 },
                 {

--- a/Assets/InputActions/FlyDangerousActions.inputactions
+++ b/Assets/InputActions/FlyDangerousActions.inputactions
@@ -1586,7 +1586,7 @@
                     "type": "PassThrough",
                     "id": "4228771a-3eee-4250-bb1b-1186f85c0c5d",
                     "expectedControlType": "Vector2",
-                    "processors": "",
+                    "processors": "NormalizeMouseScroll",
                     "interactions": ""
                 },
                 {

--- a/Assets/Scripts/InputProcessors/NormalizeMouseScroll.cs
+++ b/Assets/Scripts/InputProcessors/NormalizeMouseScroll.cs
@@ -1,0 +1,33 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+#if UNITY_EDITOR
+[InitializeOnLoad]
+#endif
+public class NormalizeMouseScroll : InputProcessor<Vector2>
+{
+    [Tooltip("Scale factor to multiply normalized scroll values")]
+    public float scrollScale = 120;
+    
+    public override Vector2 Process(Vector2 value, InputControl control) {
+        Vector2 normalizedScroll = value.normalized * scrollScale;
+        #if UNITY_STANDALONE_LINUX
+            normalizedScroll *= -1;
+        #endif
+        return normalizedScroll;
+    }
+    
+    #if UNITY_EDITOR
+    static NormalizeMouseScroll()
+    {
+        Initialize();
+    }
+    #endif
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    static void Initialize()
+    {
+        InputSystem.RegisterProcessor<NormalizeMouseScroll>();
+    }
+}

--- a/Assets/Scripts/InputProcessors/NormalizeMouseScroll.cs.meta
+++ b/Assets/Scripts/InputProcessors/NormalizeMouseScroll.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a37a785fc6599d48955b8bbcad41cb4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fix for #72 
Updated UI ScrollWheel to have the same behaviour on Linux as on Windows. Default value for Processor is 120, because that's the raw unaltered magnitude of scroll on Windows