### PR TITLE
Simple bug fixes

### DIFF
--- a/Assets/Scripts/Core/Game.cs
+++ b/Assets/Scripts/Core/Game.cs
@@ -319,6 +319,8 @@ namespace Core {
             IEnumerator LoadGame() {
                 yield return _levelLoader.ShowLoadingScreen();
 
+                Game.Instance.ActiveGameReplays = Replay.ReplaysForLevel(levelData);
+
                 // Position the active camera to the designated start location so we can be sure to load in anything
                 // important at that location as part of the load sequence
                 yield return FdPlayer.WaitForLoadingPlayer();

--- a/Assets/Scripts/Core/Replays/ReplayTimeline.cs
+++ b/Assets/Scripts/Core/Replays/ReplayTimeline.cs
@@ -48,6 +48,7 @@ namespace Core.Replays {
             Replay = replay;
             ShipReplayObject = ship;
             ship.ShipPhysics.ShipProfile = replay.ShipProfile;
+            ship.ShipPhysics.FlightParameters = replay.ShipParameters;
 
             // hide all rendering assets until told to show (e.g. by distance in FixedUpdate)
             if (ship.ShipPhysics.ShipModel != null) ship.ShipPhysics.ShipModel.SetVisible(false);


### PR DESCRIPTION
Ive decided to try to fix the huge commit mess from a few months ago, and cut it down to more bite sized commits. These two one line bug fixes should be a good start. 

The first bugfix is explicitly loading the ghosts during the level load process so, currently it is the menu leaderboard that loads the ghosts, and this creates issues for custom levels as they only load the leaderboard once a time has been set, before that they will load the last active set of ghosts which may be from a different level. Explicitly loading the correct ghosts during level load fixes this.

The other bugfix is that the replays don't load the ship parameters that are stored in the replay files, when relevant this causes stuttering.