### PR TITLE
Ship parameter rework.

### DIFF
--- a/Assets/Scripts/Core/Game.cs
+++ b/Assets/Scripts/Core/Game.cs
@@ -106,7 +106,7 @@ namespace Core {
         public ShipParameters ShipParameters {
             get {
                 if (_shipParameters != null) return _shipParameters;
-                _shipParameters = ShipParameters.Defaults;
+                _shipParameters = ShipParameters.GetDefaults();
                 var player = FdPlayer.FindLocalShipPlayer;
                 if (player != null) _shipParameters = player.ShipPhysics.FlightParameters;
                 return _shipParameters;

--- a/Assets/Scripts/Core/ShipModel/ShipParameters.cs
+++ b/Assets/Scripts/Core/ShipModel/ShipParameters.cs
@@ -1,80 +1,153 @@
 ﻿using System;
+using System.ComponentModel;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using UnityEngine;
 
 namespace Core.ShipModel {
     public class ShipParameters {
-        public static readonly ShipParameters Defaults = new() {
-            mass = 1100f,
-            drag = 0f,
-            angularDrag = 0f,
-            inertiaTensorMultiplier = 175f,
-            maxSpeed = 800f,
-            maxBoostSpeed = 932f,
-            maxThrust = 220000f,
-            maxAngularVelocity = 7f,
-            torqueThrustMultiplier = 0.08f,
-            throttleMultiplier = 1f,
-            latHMultiplier = 0.5f,
-            latVMultiplier = 0.7f,
-            pitchMultiplier = 1f,
-            rollMultiplier = 0.3f,
-            yawMultiplier = 0.8f,
-            thrustBoostMultiplier = 3.25f,
-            torqueBoostMultiplier = 2f,
-            boostSpoolUpTime = 1f,
-            totalBoostTime = 5f,
-            totalBoostRotationalTime = 6f,
-            boostMaxSpeedDropOffTime = 12f,
-            boostRechargeTime = 4f,
-            boostCapacitorPercentCost = 70f,
-            boostCapacityPercentChargeRate = 10f,
-            boostMaxDivertablePower = 0.4f,
-            minUserLimitedVelocity = 250f
+
+        private class DefaultValues
+        {
+            public const float mass = 1100f;
+            public const float drag = 0f;
+            public const float angularDrag = 0f;
+            public const float inertiaTensorMultiplier = 175f;
+            public const float maxSpeed = 800f;
+            public const float maxBoostSpeed = 932f;
+            public const float maxThrust = 220000f;
+            public const float maxAngularVelocity = 7f;
+            public const float torqueThrustMultiplier = 0.08f;
+            public const float throttleMultiplier = 1f;
+            public const float latHMultiplier = 0.5f;
+            public const float latVMultiplier = 0.7f;
+            public const float pitchMultiplier = 1f;
+            public const float rollMultiplier = 0.3f;
+            public const float yawMultiplier = 0.8f;
+            public const float thrustBoostMultiplier = 3.25f;
+            public const float torqueBoostMultiplier = 2f;
+            public const float boostSpoolUpTime = 1f;
+            public const float totalBoostTime = 5f;
+            public const float totalBoostRotationalTime = 6f;
+            public const float boostMaxSpeedDropOffTime = 12f;
+            public const float boostRechargeTime = 4f;
+            public const float boostCapacitorPercentCost = 70f;
+            public const float boostCapacityPercentChargeRate = 10f;
+            public const float boostMaxDivertablePower = 0.4f;
+            public const float minUserLimitedVelocity = 250f;
+        }
+
+        private static string[] nameList = { 
+            //IMPORTANT changing the order of these will change the hash string of the shipParameters. Only add parameters at the end! 
+            "boostCapacitorPercentCost",
+            "boostCapacityPercentChargeRate",
+            "boostMaxDivertablePower",
+            "boostMaxSpeedDropOffTime",
+            "boostRechargeTime",
+            "boostSpoolUpTime",
+            "drag",
+            "angularDrag",
+            "inertiaTensorMultiplier",
+            "latHMultiplier",
+            "latVMultiplier",
+            "mass",
+            "maxAngularVelocity",
+            "maxBoostSpeed",
+            "maxSpeed",
+            "maxThrust",
+            "minUserLimitedVelocity",
+            "pitchMultiplier",
+            "yawMultiplier",
+            "rollMultiplier",
+            "throttleMultiplier",
+            "thrustBoostMultiplier",
+            "torqueBoostMultiplier",
+            "torqueThrustMultiplier",
+            "totalBoostRotationalTime",
+            "totalBoostTime"
         };
 
-        public float angularDrag;
-        public float boostCapacitorPercentCost;
-        public float boostCapacityPercentChargeRate;
-        public float boostMaxDivertablePower;
-        public float boostMaxSpeedDropOffTime;
-        public float boostRechargeTime;
-        public float boostSpoolUpTime;
-        public float drag;
-        public float inertiaTensorMultiplier;
-        public float latHMultiplier;
-        public float latVMultiplier;
-        public float mass;
-        public float maxAngularVelocity;
-        public float maxBoostSpeed;
-        public float maxSpeed;
-        public float maxThrust;
-        public float minUserLimitedVelocity;
-        public float pitchMultiplier;
-        public float rollMultiplier;
-        public float throttleMultiplier;
-        public float thrustBoostMultiplier;
-        public float torqueBoostMultiplier;
-        public float torqueThrustMultiplier;
-        public float totalBoostRotationalTime;
-        public float totalBoostTime;
-        public float yawMultiplier;
+        public static ShipParameters GetDefaults()
+        {
+            return new();
+        }
+
+        [DefaultValue(DefaultValues.boostCapacitorPercentCost)]
+        public float boostCapacitorPercentCost = DefaultValues.boostCapacitorPercentCost;
+        [DefaultValue(DefaultValues.boostCapacityPercentChargeRate)]
+        public float boostCapacityPercentChargeRate = DefaultValues.boostCapacityPercentChargeRate;
+        [DefaultValue(DefaultValues.boostMaxDivertablePower)]
+        public float boostMaxDivertablePower = DefaultValues.boostMaxDivertablePower;
+        [DefaultValue(DefaultValues.boostMaxSpeedDropOffTime)]
+        public float boostMaxSpeedDropOffTime = DefaultValues.boostMaxSpeedDropOffTime;
+        [DefaultValue(DefaultValues.boostRechargeTime)]
+        public float boostRechargeTime = DefaultValues.boostRechargeTime;
+        [DefaultValue(DefaultValues.boostSpoolUpTime)]
+        public float boostSpoolUpTime = DefaultValues.boostSpoolUpTime;
+        [DefaultValue(DefaultValues.drag)]
+        public float drag = DefaultValues.drag;
+        [DefaultValue(DefaultValues.angularDrag)]
+        public float angularDrag = DefaultValues.angularDrag;
+        [DefaultValue(DefaultValues.inertiaTensorMultiplier)]
+        public float inertiaTensorMultiplier = DefaultValues.inertiaTensorMultiplier;
+        [DefaultValue(DefaultValues.latHMultiplier)]
+        public float latHMultiplier = DefaultValues.latHMultiplier;
+        [DefaultValue(DefaultValues.latVMultiplier)]
+        public float latVMultiplier = DefaultValues.latVMultiplier;
+        [DefaultValue(DefaultValues.mass)]
+        public float mass = DefaultValues.mass;
+        [DefaultValue(DefaultValues.maxAngularVelocity)]
+        public float maxAngularVelocity = DefaultValues.maxAngularVelocity;
+        [DefaultValue(DefaultValues.maxBoostSpeed)]
+        public float maxBoostSpeed = DefaultValues.maxBoostSpeed;
+        [DefaultValue(DefaultValues.maxSpeed)]
+        public float maxSpeed = DefaultValues.maxSpeed;
+        [DefaultValue(DefaultValues.maxThrust)]
+        public float maxThrust = DefaultValues.maxThrust;
+        [DefaultValue(DefaultValues.minUserLimitedVelocity)]
+        public float minUserLimitedVelocity = DefaultValues.minUserLimitedVelocity;
+        [DefaultValue(DefaultValues.pitchMultiplier)]
+        public float pitchMultiplier = DefaultValues.pitchMultiplier;
+        [DefaultValue(DefaultValues.yawMultiplier)]
+        public float yawMultiplier = DefaultValues.yawMultiplier;
+        [DefaultValue(DefaultValues.rollMultiplier)]
+        public float rollMultiplier = DefaultValues.rollMultiplier;
+        [DefaultValue(DefaultValues.throttleMultiplier)]
+        public float throttleMultiplier = DefaultValues.throttleMultiplier;
+        [DefaultValue(DefaultValues.thrustBoostMultiplier)]
+        public float thrustBoostMultiplier = DefaultValues.thrustBoostMultiplier;
+        [DefaultValue(DefaultValues.torqueBoostMultiplier)]
+        public float torqueBoostMultiplier = DefaultValues.torqueBoostMultiplier;
+        [DefaultValue(DefaultValues.torqueThrustMultiplier)]
+        public float torqueThrustMultiplier = DefaultValues.torqueThrustMultiplier;
+        [DefaultValue(DefaultValues.totalBoostRotationalTime)]
+        public float totalBoostRotationalTime = DefaultValues.totalBoostRotationalTime;
+        [DefaultValue(DefaultValues.totalBoostTime)]
+        public float totalBoostTime = DefaultValues.totalBoostTime;
 
         public string ToJsonString() {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
 
         [CanBeNull]
-        public static ShipParameters FromJsonString(string json) {
-            try {
-                var parameters = JsonConvert.DeserializeObject<ShipParameters>(json);
-                if (parameters?.maxAngularVelocity == 0) parameters.maxAngularVelocity = Defaults.maxAngularVelocity;
-                if (parameters?.boostSpoolUpTime == 0) parameters.boostSpoolUpTime = Defaults.boostSpoolUpTime;
+        public static ShipParameters FromJsonString(string json)
+        {
 
-                return parameters;
+            try
+            {
+                JObject parameters = JObject.Parse(json);
+                JObject defaults = JObject.Parse(ShipParameters.GetDefaults().ToJsonString());
+
+                foreach (string parameter in nameList)
+                {
+                    if (!parameters.ContainsKey(parameter))
+                        parameters.Add(parameter, defaults[parameter]);
+                }
+                return JsonConvert.DeserializeObject<ShipParameters>(parameters.ToString());
             }
-            catch (Exception e) {
+            catch (Exception e)
+            {
                 Debug.LogWarning(e.Message);
                 return null;
             }

--- a/Assets/Scripts/Core/ShipModel/ShipPhysics.cs
+++ b/Assets/Scripts/Core/ShipModel/ShipPhysics.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.ComponentModel;
 using System.Linq;
 using Core.Player;
 using Core.ShipModel.Feedback;
@@ -11,6 +12,8 @@ using Gameplay;
 using JetBrains.Annotations;
 using Misc;
 using UnityEngine;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Core.ShipModel {
     public enum BoostStatus {
@@ -78,7 +81,7 @@ namespace Core.ShipModel {
 
         public ShipParameters FlightParameters {
             get {
-                if (!targetRigidbody || _shipParameters == null) return ShipParameters.Defaults;
+                if (!targetRigidbody || _shipParameters == null) return ShipParameters.GetDefaults();
                 return _shipParameters;
             }
             set {
@@ -175,7 +178,7 @@ namespace Core.ShipModel {
 
         public void Awake() {
             // init physics
-            FlightParameters = ShipParameters.Defaults;
+            FlightParameters = ShipParameters.GetDefaults();
 
             // get components
             _modifierEngine = GetComponent<ModifierEngine>();

--- a/Assets/Scripts/Gameplay/Game Modes/GameModeHandler.cs
+++ b/Assets/Scripts/Gameplay/Game Modes/GameModeHandler.cs
@@ -310,7 +310,7 @@ namespace Gameplay.Game_Modes {
         }
 
         private bool IsValid() {
-            return !Application.version.Contains("-dev") && Game.Instance.ShipParameters.ToJsonString().Equals(ShipParameters.Defaults.ToJsonString());
+            return !Application.version.Contains("-dev") && Game.Instance.ShipParameters.ToJsonString().Equals(ShipParameters.GetDefaults().ToJsonString());
         }
 
         private IEnumerator ShowLevelAndMusicName() {

--- a/Assets/Scripts/Menus/Options/DevPanel.cs
+++ b/Assets/Scripts/Menus/Options/DevPanel.cs
@@ -35,7 +35,7 @@ public class DevPanel : MonoBehaviour {
 
     // Start is called before the first frame update
     private void Start() {
-        var defaults = ShipParameters.Defaults;
+        var defaults = ShipParameters.GetDefaults();
 
         massTextField.placeholder.GetComponent<Text>().text =
             defaults.mass.ToString(CultureInfo.InvariantCulture);
@@ -92,7 +92,7 @@ public class DevPanel : MonoBehaviour {
     }
 
     public void RestoreDefaults() {
-        UpdateTextFields(ShipParameters.Defaults);
+        UpdateTextFields(ShipParameters.GetDefaults());
     }
 
     public void CopyToClipboard() {
@@ -162,7 +162,7 @@ public class DevPanel : MonoBehaviour {
     }
 
     public ShipParameters GetFlightParams() {
-        if (!_initialised) return ShipParameters.Defaults;
+        if (!_initialised) return ShipParameters.GetDefaults();
 
         return new ShipParameters {
             mass =


### PR DESCRIPTION
This PR definitely deserves explanation, and I'l try to do my best to keep it concise. Some of my solutions might have had a more straightforward solution, but there ware a lot of limitations and edge cases of dotnet, and the json parser that finding a way to work around all of those at all was difficult. 

Firstly, I removed the object containing the default parameters, and replaced it with a function. This I did because I ran into a problem that when I loaded a level/game where I changed the parameters during the loading process, the defaults would end up changed too. Despite them being "read only", they would somehow end up overwritten, breaking the check on if the race is valid. The solution for this was to make it a function instead, since this is immune from getting overwritten. I also changed every instance of the object getting called so the game is not broken. 

I gave everything a default value so that the json parser could understand the difference between a parameter that is missing, and a parameter that is set to zero. This is also why all the default values are constants now, otherwise the compiler would not allow this. 

I have added a list of the string names of all the ship parameters, this serves two functions. One being a list of names which can be searched up in the JSON structure, and that can be iterated against. Also it functions as the order of operations for the hash string generator, because JSON order can't be trusted (and you can't apparently iterate against a list of constants), but that is not included in this PR. 