### PR TITLE
Properly loading custom race ghosts

### DIFF
--- a/Assets/Scripts/Core/Game.cs
+++ b/Assets/Scripts/Core/Game.cs
@@ -319,8 +319,6 @@ namespace Core {
             IEnumerator LoadGame() {
                 yield return _levelLoader.ShowLoadingScreen();
 
-                Game.Instance.ActiveGameReplays = Replay.ReplaysForLevel(levelData);
-
                 // Position the active camera to the designated start location so we can be sure to load in anything
                 // important at that location as part of the load sequence
                 yield return FdPlayer.WaitForLoadingPlayer();

--- a/Assets/Scripts/Menus/Main Menu/LoadCustomMenu.cs
+++ b/Assets/Scripts/Menus/Main Menu/LoadCustomMenu.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Core;
 using Core.MapData;
+using Core.Replays;
 using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.UI;
@@ -48,6 +49,13 @@ namespace Menus.Main_Menu {
         public void StartMap() {
             startButton.interactable = false;
             var levelData = _levelData ?? new LevelData();
+
+            var replaysForLevel = Replay.ReplaysForLevel(levelData).OrderBy(r => r.ScoreData.raceTime).ToList();
+            Game.Instance.ActiveGameReplays = new List<Replay>();
+            if(replaysForLevel.Count() > 0){
+                Game.Instance.ActiveGameReplays.Add(replaysForLevel.First());
+            }
+                
             FdNetworkManager.Instance.StartGameLoadSequence(SessionType.Singleplayer, levelData);
         }
 

--- a/Assets/Scripts/Menus/Main Menu/LoadCustomMenu.cs
+++ b/Assets/Scripts/Menus/Main Menu/LoadCustomMenu.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Collections.Generic;
 using Core;
 using Core.MapData;
 using Core.Replays;


### PR DESCRIPTION
Instead of my stupid overwrite of all the loaded ghosts during the level loading process, just load the correct ghost for custom races + removing any previously loaded ghosts. 