### PR TITLE
Ship-parameter and settings interactions fixes

### DIFF
--- a/Assets/Scripts/Core/Game.cs
+++ b/Assets/Scripts/Core/Game.cs
@@ -316,6 +316,14 @@ namespace Core {
                 yield return new WaitUntil(() => FindObjectsOfType<LoadingPlayer>().All(loadingPlayer => loadingPlayer.isLoaded));
             }
 
+            // Set the textfields in the DevPanel to the included parameters from the leveldata so changing the settings wont change
+            // the flight parameters unexpectedly in the case it is already loaded.
+            var optionsMenu = GetComponentInChildren<Menus.Options.OptionsMenu>(true);
+            if(optionsMenu) {
+                var devPanel =  optionsMenu.GetComponentInChildren<DevPanel>(true); 
+                if (devPanel) devPanel.UpdateTextFields(Game.Instance.LoadedLevelData.shipParameters); 
+            }
+
             IEnumerator LoadGame() {
                 yield return _levelLoader.ShowLoadingScreen();
 
@@ -349,6 +357,8 @@ namespace Core {
 
                 // set up graphics settings (e.g. camera FoV)
                 ApplyGameOptions();
+
+                
 
 #if !NO_PAID_ASSETS
                 // gpu instancer VR initialisation (paid asset!)

--- a/Assets/Scripts/Menus/Options/DevPanel.cs
+++ b/Assets/Scripts/Menus/Options/DevPanel.cs
@@ -162,7 +162,7 @@ public class DevPanel : MonoBehaviour {
     }
 
     public ShipParameters GetFlightParams() {
-        if (!_initialised) return ShipParameters.Defaults;
+        if (!_initialised) return Game.Instance.ShipParameters;
 
         return new ShipParameters {
             mass =


### PR DESCRIPTION
It turned out that loading ship-parameters using the level loading process did not change the settings dev-panel text-fields, and when the dev-panel was not loaded applying any settings changes would result in default parameters being applied for any settings change.

So if you first opened the dev-panel with different ship-parameters, these settings would always be reset to on a settings change, and if you never opened the dev-panel it would result in the default parameters loaded on a settings change. 

This is a issue because when a level is loaded it did only change the physics parameters, and the settings text-fields were unchanged. 

With this patch loading a level checks if the dev-panel is loaded, and updates the text-fields, and if the panel is unloaded instead of returning default parameters it now returns the active parameters. These two fixes seem to solve all the settings panels interaction issues I'm aware off. 