### PR TITLE
Custom level loading pannel improvements

### DIFF
--- a/Assets/Scripts/Core/MapData/Level.cs
+++ b/Assets/Scripts/Core/MapData/Level.cs
@@ -131,34 +131,29 @@ namespace Core.MapData {
             }
             var fileNames = Directory.GetFiles(customPath);
 
-            // We want to remove indexes from the list, but we also want to itterate over it, we cant do both at once, so we copy it
-            var customNameList = new List<string>(_customNameList);
-            int i = 0;
-            foreach ( var f in customNameList) {
-                if(!fileNames.Contains(f)) {
+            for (int i = _customNameList.Count - 1; i >= 0; i--) {
+                if (!fileNames.Contains(_customNameList[i])){ 
                     _customNameList.RemoveAt(i);
                     _customLevels.RemoveAt(i);
                 }
-                else {
-                    i++;
-                }
             }
-            i = 0;
+
+            int j = 0;
             foreach ( string f in fileNames)
             {
                 if (!_customNameList.Contains(f))
                 {
                     try {
                         // the thing that might fail first so the lists stay aligned
-                        _customLevels.Insert(i,loadFromZip(f)); 
-                        _customNameList.Insert(i,f);
+                        _customLevels.Insert(j,loadFromZip(f)); 
+                        _customNameList.Insert(j,f);
                     }
                     catch {
                         // shift back the index so it is as if the impropper file never was included in fileNames
-                        i--; 
+                        j--; 
                     }
                 }
-                i++;
+                j++;
             }
         }
 


### PR DESCRIPTION
Honestly the most impactful thing here is having the code check for jpg's, and accepting them. The biggest bottleneck with the loading speed of the file size. And with all the files I had due to the uncapped levels, it was in the range of seconds, hence a fix.

Aside from that simple impactful tweak, I may or may not have over-engineered logic that checks if there are new/removed levels files, and inserts them at the correct place in the list. This is nice because the second time you load the menu you don't have to wait for the list to be rebuild. 

I am quite sure my solution works as advertised, and I tested it quite extensively. The sane solution here would have been a _customNameList != fileNames check, and rebuild it from scratch, but I only thought of that after I was done with this madness.

Now it works this way, it may actually be worth just saving the _customLevels and _customNameList to disk, so loading levels can always be fast, but that would be a project for anther time.