### PR TITLE
Level preloading, to prevent stutters in the menu

### DIFF
--- a/Assets/Scripts/Core/Game.cs
+++ b/Assets/Scripts/Core/Game.cs
@@ -143,6 +143,10 @@ namespace Core {
             // bootstrap for various game mode types
             GameModeHandler = GetComponent<GameModeHandler>();
 
+            // load levels before start so they dont stutter the game in the menu
+            Level.LoadCustomLevels();
+            Level.List();
+
             // if there's a user object when the game starts, enable input (usually in the editor!)
             FindObjectOfType<ShipPlayer>()?.User.EnableGameInput();
             LoadBindings();


### PR DESCRIPTION
These two functions take longer the first time they are run, and they are run during opening of level select panels, causing a stutter on first open. So running these functions during startup, prevents the game from stuttering when opening certain menu's. 

Technically this does not save time, but overall I would say it is a user experience improvement.

I think that at least for me this is the last patch for a while. So I think with this it is a good idea to just update the steam version. I would rather avoid having to add another custom level to the hash list, if one happens to come out soonish. 