### PR TITLE
Copy to json to clipboard compacting

### DIFF
--- a/Assets/Scripts/Menus/Pause Menu/PauseMenu.cs
+++ b/Assets/Scripts/Menus/Pause Menu/PauseMenu.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Text;
 using Core;
 using Core.Player;
 using FdUI;
@@ -83,7 +84,34 @@ namespace Menus.Pause_Menu {
 
         public void CopyLocationToClipboard() {
             PlayApplySound();
-            GUIUtility.systemCopyBuffer = Game.Instance.LevelDataAtCurrentPosition.ToJsonString();
+
+            string savedString =  Game.Instance.LevelDataAtCurrentPosition.ToJsonString();
+            bool inList  = false;
+            bool inText = false;
+            int treeDepth = 0;
+            
+            StringBuilder compactJson = new StringBuilder();
+
+            foreach (char charicter in savedString)
+            {
+                if(charicter == char.Parse("[")){ inList = true ;}
+                if(charicter == char.Parse("]")){ inList = false ;}
+                if(charicter == '\"'){ inText = !inText;}
+
+                if(inList&&!inText){
+                    if (charicter == char.Parse("{")) { treeDepth++; }
+                    else if (charicter == char.Parse("}")) { treeDepth--; } 
+                }
+
+                if (treeDepth>=1&&!inText)
+                {
+                    if (charicter != ' ' && charicter != '\n' && charicter != '\r')
+                    { compactJson.Append(charicter); }
+                }
+                else {compactJson.Append(charicter); }
+            }
+
+            GUIUtility.systemCopyBuffer = compactJson.ToString();
             var copyConfirmTransform = copyConfirmationText.transform;
             copyConfirmTransform.localPosition = new Vector3(copyConfirmTransform.localPosition.x, 55, copyConfirmTransform.position.z);
             copyConfirmationText.color = new Color(1f, 1f, 1f, 1f);


### PR DESCRIPTION
I noticed that if you copied a long race like Death Valley the clipboard string would become so long it doesn't fit in the custom json window. 

I actually already had written a thing for this for RaceMate that compresses all items in a list to a single line
i.e. all checkpoints, singularities, and billboards each become a single line, with the idea that this best way to compact the json string, while preserving readability as much as possible. It is done via a custom mechanism because I felt like none of the default compacting options fit with my readability requirement. 

It will no longer work nicely once we start dealing with lists in lists, but that limitation probably wont be relevant anytime soon.