### PR TITLE
Fix for load next level not appearing on compleation of custom levels

### DIFF
--- a/Assets/Scripts/Core/MapData/Level.cs
+++ b/Assets/Scripts/Core/MapData/Level.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
@@ -197,9 +197,8 @@ namespace Core.MapData {
                 thumbnail = Resources.Load<Sprite>("Levels/fallback-thumbnail");
             }
 
-            // set as free roam for now
-            return new Level(levelData.name, levelData, thumbnail, GameType.FreeRoam, false);
-       }
+            return new Level(levelData.name, levelData, thumbnail, levelData.gameType, false);
+        }
 
         public static List<Level> ListCustom()
         {
@@ -209,11 +208,11 @@ namespace Core.MapData {
 
         public static Level FromString(string locationString)
         {
-            return FdEnum.FromString(List(), locationString);
+            return FdEnum.FromString(List().Concat(_customLevels), locationString);
         }
 
         public static Level FromId(int id) {
-            return FdEnum.FromId(List(), id);
+            return FdEnum.FromId(List().Concat(_customLevels), id);
         }
     }
 }


### PR DESCRIPTION
A small improvement
The load next level did not show up when completing a custom level
The reason ware because the nextLevelValid check assumed the levels ware findable in FromId(), which only looked at build in levels. I also made sure to set the game type labels of custom levels correctly now. 

The nextLevelValid check still assumes the current and next level must be of the same gametype, so if a mix of game types are loaded in custom levels, some level transitions will still be blocked, but for most cases and people this should work. I could probably figure something out to fix that if you think that that could be nicer. 

There is a edge-case where if the first custom level loaded is a puzzle map, and you complete the last loaded puzzle level, the load next level should end up referencing the fist custom map (if it ware a puzzle map).